### PR TITLE
Made event card mobile responsive

### DIFF
--- a/src/components/Event.jsx
+++ b/src/components/Event.jsx
@@ -12,11 +12,11 @@ const Event = ({
   description = "",
 }) => {
   return (
-    <div className="flex rounded-xl overflow-hidden shadow max-w-2xl">
-      <div className="p-4 text-white text-center w-1/4 bg-gradient-to-br from-hiss-blue to-hiss-purple">
-        <div className="text-4xl font-bold">{month}</div>
-        <div className="text-4xl font-semibold ">{day}</div>
-        <div className="text-xl font-normal">{time}</div>
+    <div className="flex rounded-xl overflow-hidden shadow justify-center w-[95%] sm:w-[80%]">
+      <div className="p-4 text-white text-center w-1/3 sm:w-1/4 bg-gradient-to-br from-hiss-blue to-hiss-purple">
+        <div className="text-3xl sm:text-4xl font-bold">{month}</div>
+        <div className="text-3xl sm:text-4xl font-semibold ">{day}</div>
+        <div className="text-md sm:text-xl font-normal">{time}</div>
       </div>
 
       <div className="flex-1 pl-4">


### PR DESCRIPTION
![image](https://github.com/acm-ucr/hiss-website/assets/68032044/3edde2e0-c77d-43e3-83a2-57a4ec568a73)
Less than 300px wide is where some issues still remain. This seems to affect the Samsung Galaxy fold but not any other devices that I simulated. 